### PR TITLE
kontextova ponuka - prehravanie/listovanie

### DIFF
--- a/script.module.stream.resolver/lib/xbmcutil.py
+++ b/script.module.stream.resolver/lib/xbmcutil.py
@@ -80,7 +80,17 @@ def add_dir(name,params,logo='',infoLabels={},menuItems={}):
         if not type(action) == type({}):
             items.append((mi,action))
         else:
-            items.append((mi,'RunPlugin(%s)'%_create_plugin_url(action)))
+            if 'action-type' in action:
+                action_type = action['action-type']
+                del action['action-type']
+                if action_type == 'list':
+                    items.append((mi,'Container.Update(%s)'%_create_plugin_url(action)))
+                elif action_type == 'play':
+                    items.append((mi,'PlayMedia(%s)'%_create_plugin_url(action)))
+                else:
+                    items.append((mi,'RunPlugin(%s)'%_create_plugin_url(action)))
+            else:
+                items.append((mi,'RunPlugin(%s)'%_create_plugin_url(action)))
     if len(items) > 0:
         liz.addContextMenuItems(items)
     return xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=_create_plugin_url(params),listitem=liz,isFolder=True)
@@ -111,7 +121,18 @@ def add_video(name,params={},logo='',infoLabels={},menuItems={}):
         if not type(action) == type({}):
             items.append((mi,action))
         else:
-            items.append((mi,'RunPlugin(%s)'%_create_plugin_url(action)))
+            if 'action-type' in action:
+                action_type = action['action-type']
+                del action['action-type']
+                if action_type == 'list':
+                    items.append((mi,'Container.Update(%s)'%_create_plugin_url(action)))
+                elif action_type == 'play':
+                    items.append((mi,'PlayMedia(%s)'%_create_plugin_url(action)))
+                else:
+                    items.append((mi,'RunPlugin(%s)'%_create_plugin_url(action)))
+            else:
+                items.append((mi,'RunPlugin(%s)'%_create_plugin_url(action)))
+                
     if len(items) > 0:
         li.addContextMenuItems(items)
     return xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=url,listitem=li,isFolder=False)
@@ -146,7 +167,7 @@ def save_to_file(url,file):
         traceback.print_exc()
 
 def load_subtitles(url):
-    if not (url=='' or url==None):	
+    if not (url=='' or url==None):
         local = xbmc.translatePath(__addon__.getAddonInfo('path'))
         if not os.path.exists(local):
             os.makedirs(local)


### PR DESCRIPTION
Ahoj, pracoval som na mixer.cz plugine a mal som problemy prehravat/listovat videa z kontextovej ponuky. Pri pouziti RunPlugin som mal v logu vzdy: "Attempt to use invalid handle -1".

Pre spustanie videii z kontextovej ponuky bolo nutne pouzit PlayMedia a pre nacitanie zoznamu Container.Update.

Pri vytvarani polozky kontextovej ponuky je mozne pouzit kluc 'action-type' s hodnotou 'list' alebo 'play', podla toho ci chceme z polozky prehravat/listovat ak sa pouzije nieco ine alebo bude kluc chybat tak sa pouzije RunPlugin.
